### PR TITLE
refactor(rust): refactored identity show command to use rpc abstracti…

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/identity.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/identity.rs
@@ -1,5 +1,6 @@
 use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::Cow;
+use serde::Serialize;
 
 use ockam_core::CowBytes;
 
@@ -26,7 +27,7 @@ impl<'a> CreateIdentityResponse<'a> {
     }
 }
 
-#[derive(Debug, Clone, Decode, Encode)]
+#[derive(Debug, Clone, Decode, Encode,Serialize)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct LongIdentityResponse<'a> {
@@ -45,7 +46,7 @@ impl<'a> LongIdentityResponse<'a> {
     }
 }
 
-#[derive(Debug, Clone, Decode, Encode)]
+#[derive(Debug, Clone, Decode, Encode,Serialize)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct ShortIdentityResponse<'a> {

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -26,7 +26,7 @@ impl IdentityCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             IdentitySubcommand::Create(c) => c.run(options),
-            IdentitySubcommand::Show(c) => c.run(options).unwrap(),
+            IdentitySubcommand::Show(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -95,6 +95,7 @@ pub(crate) fn delete_tcp_connection(
 }
 
 /// Construct a request to export Identity
+#[allow(unused)]
 pub(crate) fn long_identity() -> Result<Vec<u8>> {
     let mut buf = vec![];
     Request::post("/node/identity/actions/show/long").encode(&mut buf)?;
@@ -394,6 +395,7 @@ pub(crate) fn parse_transport_status(
     ))
 }
 
+#[allow(unused)]
 pub(crate) fn parse_long_identity_response(
     resp: &[u8],
 ) -> Result<(Response, models::identity::LongIdentityResponse<'_>)> {


### PR DESCRIPTION
…on and to stop mapping errors manually

refactored the identity show command, implemented output trait for the two types of Identity Responses and marked 2 functions which are now not being used as allow unused

Signed-off-by: Divyank Aggarwal <divyank.aggarwal@remotestate.com>

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [ ] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
